### PR TITLE
Fix scalar field perturbation compile errors

### DIFF
--- a/include/perturbations.h
+++ b/include/perturbations.h
@@ -102,8 +102,6 @@ struct perturbations
    *  'thermodynamics' structures) */
 
   //@{
-  int index_pt_psi;
-  int index_pt_dpsi;
 
   short has_perturbations; /**< do we need to compute perturbations at all ? */
 
@@ -484,6 +482,8 @@ struct perturbations_vector
   int index_pt_Gamma_fld;  /**< unique dark energy dynamical variable in PPF case */
   int index_pt_phi_scf;  /**< scalar field density */
   int index_pt_phi_prime_scf;  /**< scalar field velocity */
+  int index_pt_psi;  /**< additional scalar field perturbation */
+  int index_pt_dpsi; /**< derivative of additional scalar field perturbation */
   int index_pt_delta_ur; /**< density of ultra-relativistic neutrinos/relics */
   int index_pt_theta_ur; /**< velocity of ultra-relativistic neutrinos/relics */
   int index_pt_shear_ur; /**< shear of ultra-relativistic neutrinos/relics */

--- a/source/background.c
+++ b/source/background.c
@@ -3000,3 +3000,11 @@ double d2V_scf_dphi2(struct background *pba, double phi) {
          + 2.0 * pba->beta_scf
          + 2.0 * pba->delta_scf * (1.0 - log(phi / pba->psi0_scf)) / (phi * phi);
 }
+
+double dV_scf(struct background *pba, double phi) {
+  return dV_scf_dphi(pba, phi);
+}
+
+double ddV_scf(struct background *pba, double phi) {
+  return d2V_scf_dphi2(pba, phi);
+}


### PR DESCRIPTION
## Summary
- add `index_pt_psi`/`index_pt_dpsi` fields to perturbation vectors
- move psi index definition and add psi equations in `perturbations.c`
- implement missing potential derivative wrappers in `background.c`
- ensure C prototypes for potential derivatives when using C++
- zero and propagate psi variables during vector updates

## Testing
- `make class -j4`

------
https://chatgpt.com/codex/tasks/task_e_685650ce1f348320aa634b4c066a9972