### PR TITLE
Fix scalar field allocation call

### DIFF
--- a/source/input.c
+++ b/source/input.c
@@ -5686,7 +5686,7 @@ int input_default_params(struct background *pba,
   //pba->scf_has_potential = _TRUE_;
   //pba->scf_potential = user_defined;
   pba->scf_parameters_size = 10;
-  class_alloc(pba->scf_parameters, sizeof(double) * 10);
+  class_alloc(pba->scf_parameters, sizeof(double) * 10, pba->error_message);
   pba->scf_parameters[0] = 1.0;   // alpha
   pba->scf_parameters[1] = 0.5;   // lambda
   pba->scf_parameters[2] = 0.1;   // beta


### PR DESCRIPTION
## Summary
- correct `class_alloc` call in `input_default_params`

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68579791baf483209f856247b69585ce