### PR TITLE
Fix SCF parameter default initialization

### DIFF
--- a/source/input.c
+++ b/source/input.c
@@ -1638,26 +1638,6 @@ int input_read_parameters(struct file_content * pfc,
                           ErrorMsg errmsg){
 
   /** Summary: */
-  double *scf_parameters;
-  int scf_parameters_size;
-  
-
-  if (scf_parameters_size != 10) {
-    class_stop(errmsg, "Expected 10 parameters for scf_parameters, got %d", scf_parameters_size);
-  }
-
-  pba->alpha_scf         = scf_parameters[0];
-  pba->lambda_scf        = scf_parameters[1];
-  pba->beta_scf          = scf_parameters[2];
-  pba->gamma_scf         = scf_parameters[3];
-  pba->k_scf             = scf_parameters[4];
-  pba->omega_scf         = scf_parameters[5];
-  pba->delta_scf         = scf_parameters[6];
-  pba->psi0_scf          = scf_parameters[7];
-  pba->phi_ini_scf       = scf_parameters[8];
-  pba->phi_prime_ini_scf = scf_parameters[9];
-
-  free(scf_parameters);
 
   /** Define local variables */
   int input_verbose=0;
@@ -5686,7 +5666,7 @@ int input_default_params(struct background *pba,
   //pba->scf_has_potential = _TRUE_;
   //pba->scf_potential = user_defined;
   pba->scf_parameters_size = 10;
-  class_alloc(pba->scf_parameters, sizeof(double) * 10);
+  class_alloc(pba->scf_parameters, sizeof(double) * 10, pba->error_message);
   pba->scf_parameters[0] = 1.0;   // alpha
   pba->scf_parameters[1] = 0.5;   // lambda
   pba->scf_parameters[2] = 0.1;   // beta


### PR DESCRIPTION
## Summary
- remove unused SCF parameter block in `input_read_parameters`
- keep scalar field array allocation with error string

## Testing
- `make class libclass.a`

------
https://chatgpt.com/codex/tasks/task_e_68579791baf483209f856247b69585ce